### PR TITLE
Update README and Help/Usage - AWS_REGION for EC2 Instance Profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ credentials. It will look for the `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` environment variables, the default credentials
 profile (e.g. `~/.aws/credentials`), and finally any instance profile
 credentials for systems running on EC2 instances.
+Note: export AWS_REGION="<region>" variable if using EC2 Instance Profiles.
+This is in addition to SNEAKER_S3_PATH & SNEAKER_MASTER_KEY. Failure to
+export AWS_REGION will result in 'could not find region configuration'
+exception when running sneaker
 
 In general, if the `aws` command works, `sneaker` should work as well.
 

--- a/cmd/sneaker/main.go
+++ b/cmd/sneaker/main.go
@@ -32,9 +32,10 @@ Options:
   -h --help  Show this help information.
 
 Environment Variables:
-  SNEAKER_MASTER_KEY      The KMS key to use when encrypting secrets.
-  SNEAKER_MASTER_CONTEXT  The KMS encryption context to use for stored secrets.
-  SNEAKER_S3_PATH         Where secrets will be stored (e.g. s3://bucket/path).
+  SNEAKER_MASTER_KEY      (Required) The KMS key to use when encrypting secrets.
+  SNEAKER_MASTER_CONTEXT  (Optional) The KMS encryption context to use for stored secrets.
+  SNEAKER_S3_PATH         (Required) Where secrets will be stored (e.g. s3://bucket/path).
+  AWS_REGION		  (Required for Instance Profiles) Region of s3 Bucket (e.g. us-east-1, us-west-2).
 `
 
 func main() {


### PR DESCRIPTION
With the recent move to the go aws sdk, sneaker will fail on EC2 Instances using only Instance profiles with:
-bash-4.1$ sneaker ls
2015/04/30 23:28:08 could not find region configuration.

bash-4.1$ export AWS_REGION="us-east-1"
bash-4.1$ sneaker ls
key                           modified          size  etag
testsecret/                         2015-04-30T20:21  -224  XXXXXXXXXXXX