### PR TITLE
Add support for reading from STDIN on upload

### DIFF
--- a/cmd/sneaker/main.go
+++ b/cmd/sneaker/main.go
@@ -86,10 +86,7 @@ func main() {
 
 		log.Printf("uploading %s", file)
 
-		f, err := os.Open(file)
-		if err != nil {
-			log.Fatal(err)
-		}
+		f := openPath(file, os.Open, os.Stdin)
 		defer f.Close()
 
 		if err := manager.Upload(path, f); err != nil {


### PR DESCRIPTION
The README indicates that the upload subcommand can read from STDIN by supplying `-` as the filename. These changes add support for reading from STDIN via the same utility function that is already used by pack/unpack.