### PR TITLE
Whitespace change to test CI against current master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sneaker
+# Sneaker 
 
 [![Build Status](https://travis-ci.org/codahale/sneaker.svg?branch=master)](https://travis-ci.org/codahale/sneaker)
 [![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/codahale/sneaker/blob/master/LICENSE)


### PR DESCRIPTION
Please ignore - checking that CI fails w/ current master branch (due to change from go 1.4 to go 1.7), then will close this PR.